### PR TITLE
Process csv as lists in metadata

### DIFF
--- a/ibutsu_utils/upload.py
+++ b/ibutsu_utils/upload.py
@@ -57,6 +57,9 @@ def parse_metadata(metadata_list):
             current_data = current_data[key]
         # Finally, set the actual value
         key = keys[-1]
+        # Properly process list types
+        if ',' in value:
+            value = value.split(',')
         current_data[key] = value
     return metadata
 


### PR DESCRIPTION
In order to import the list of tags, we need to split the comma-separated metadata values. 